### PR TITLE
Remove unused SessionFilterForm class

### DIFF
--- a/laptimes/forms.py
+++ b/laptimes/forms.py
@@ -199,20 +199,3 @@ class JSONUploadForm(forms.Form):
         return file
 
 
-class SessionFilterForm(forms.Form):
-    """Form for filtering sessions and laps"""
-    session = forms.ModelChoiceField(
-        queryset=None,  # Will be set in __init__
-        required=False,
-        empty_label="Select a session",
-        widget=forms.Select(attrs={'class': 'form-select'})
-    )
-
-    driver = forms.CharField(
-        required=False,
-        widget=forms.Select(attrs={'class': 'form-select'})
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields['session'].queryset = Session.objects.all()


### PR DESCRIPTION
## Summary
- Remove unused `SessionFilterForm` class from `laptimes/forms.py`
- This form was defined but never imported or used anywhere in the codebase
- Code cleanup to reduce maintenance burden

## Test plan
- [x] All existing tests pass (38/38)
- [x] No functional changes to the application
- [x] Verified no imports or references to the removed class

🤖 Generated with [Claude Code](https://claude.ai/code)