### PR TITLE
Add explanatory tooltip to consistency metric

### DIFF
--- a/laptimes/templates/laptimes/session_detail.html
+++ b/laptimes/templates/laptimes/session_detail.html
@@ -144,7 +144,12 @@
                         
                         <div class="text-center">
                             <small class="text-muted">
-                                Consistency: ±{{ stats.consistency|floatformat:3 }}s
+                                <span data-bs-toggle="tooltip" 
+                                      data-bs-placement="top" 
+                                      title="Standard deviation of lap times. For sessions with 4+ laps, the two worst laps are excluded to better reflect typical performance consistency.">
+                                    Consistency: ±{{ stats.consistency|floatformat:3 }}s
+                                    <i class="bi bi-info-circle"></i>
+                                </span>
                             </small>
                         </div>
                     </div>
@@ -565,6 +570,12 @@ document.addEventListener('DOMContentLoaded', function() {
     
     driverFilter.value = currentDriver;
     sortBy.value = currentSort;
+    
+    // Initialize Bootstrap tooltips
+    var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+    var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+        return new bootstrap.Tooltip(tooltipTriggerEl);
+    });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add Bootstrap tooltip to consistency metric in driver statistics grid
- Include info icon (ℹ️) next to consistency value for better UX
- Explain that consistency represents standard deviation with statistical filtering

## Changes Made
- **Enhanced UX**: Added hover tooltip to explain consistency calculation
- **Visual Indicator**: Added Bootstrap info icon next to consistency metric
- **Clear Explanation**: Tooltip explains standard deviation and lap filtering logic
- **JavaScript Integration**: Initialize Bootstrap tooltips on page load

## Technical Details
The tooltip explains that:
- Consistency = standard deviation of lap times
- For sessions with 4+ laps, the two worst laps are excluded
- This provides a more accurate measure of typical driving consistency

## Test Plan
- [x] Verify tooltip appears on hover over consistency metric
- [x] Confirm info icon displays properly
- [x] Test tooltip positioning and readability
- [x] Ensure no JavaScript errors in browser console

🤖 Generated with [Claude Code](https://claude.ai/code)