### PR TITLE
Implement out lap identification and performance exclusion

### DIFF
--- a/laptimes/models.py
+++ b/laptimes/models.py
@@ -34,16 +34,16 @@ class Session(models.Model):
         return f"{self.track} - {self.car} ({self.session_type})"
 
     def get_fastest_lap(self):
-        """Get the fastest lap in this session"""
-        return self.laps.order_by("total_time").first()
+        """Get the fastest lap in this session - exclude out laps"""
+        return self.laps.filter(lap_number__gt=0).order_by("total_time").first()
 
     def get_drivers(self):
         """Get list of unique drivers in this session"""
         return self.laps.values_list("driver_name", flat=True).distinct()
 
     def get_optimal_lap_time(self, driver_name):
-        """Calculate optimal lap time (sum of best sectors) for a driver"""
-        driver_laps = self.laps.filter(driver_name=driver_name)
+        """Calculate optimal lap time (sum of best sectors) for a driver - exclude out laps"""
+        driver_laps = self.laps.filter(driver_name=driver_name, lap_number__gt=0)
         if not driver_laps.exists():
             return None
 
@@ -70,46 +70,56 @@ class Session(models.Model):
         return sum(best_sectors) if best_sectors else None
 
     def get_driver_statistics(self):
-        """Calculate comprehensive statistics for each driver"""
+        """Calculate comprehensive statistics for each driver - exclude out laps"""
         stats = {}
 
         for driver_name in self.get_drivers():
-            driver_laps = self.laps.filter(driver_name=driver_name)
-            lap_times = [lap.total_time for lap in driver_laps]
+            # Get all laps for total count display
+            all_driver_laps = self.laps.filter(driver_name=driver_name)
+            # Get only racing laps for performance calculations
+            driver_racing_laps = self.laps.filter(driver_name=driver_name, lap_number__gt=0)
+            racing_lap_times = [lap.total_time for lap in driver_racing_laps]
 
-            if not lap_times:
-                continue
+            # Use all laps count for display, but racing laps for calculations
+            if not racing_lap_times:
+                # If no racing laps, skip this driver or use all laps as fallback
+                if not all_driver_laps.exists():
+                    continue
+                # Fallback to all laps if only out laps exist
+                lap_times = [lap.total_time for lap in all_driver_laps]
+                racing_lap_times = lap_times
 
-            # Calculate basic statistics
-            best_lap_time = min(lap_times)
-            avg_lap_time = sum(lap_times) / len(lap_times)
+            # Calculate basic statistics using racing laps only
+            best_lap_time = min(racing_lap_times)
+            avg_lap_time = sum(racing_lap_times) / len(racing_lap_times)
 
             # Calculate consistency (standard deviation) - drop two worst laps
-            if len(lap_times) > 3:
+            if len(racing_lap_times) > 3:
                 # Sort lap times and drop the two worst (highest) times
-                sorted_times = sorted(lap_times)
+                sorted_times = sorted(racing_lap_times)
                 filtered_times = sorted_times[:-2]  # Remove two worst laps
                 filtered_avg = sum(filtered_times) / len(filtered_times)
                 variance = sum((x - filtered_avg) ** 2 for x in filtered_times) / len(
                     filtered_times
                 )
                 consistency = variance**0.5
-            elif len(lap_times) > 1:
-                # If 3 or fewer laps, use all laps for consistency
-                variance = sum((x - avg_lap_time) ** 2 for x in lap_times) / len(
-                    lap_times
+            elif len(racing_lap_times) > 1:
+                # If 3 or fewer laps, use all racing laps for consistency
+                variance = sum((x - avg_lap_time) ** 2 for x in racing_lap_times) / len(
+                    racing_lap_times
                 )
                 consistency = variance**0.5
             else:
                 consistency = 0.0
 
-            # Get optimal lap time
+            # Get optimal lap time (already excludes out laps)
             optimal_lap_time = self.get_optimal_lap_time(driver_name)
 
             stats[driver_name] = {
                 "best_lap_time": best_lap_time,
                 "optimal_lap_time": optimal_lap_time,
-                "lap_count": len(lap_times),
+                "lap_count": all_driver_laps.count(),  # Show total lap count including out laps
+                "racing_lap_count": len(racing_lap_times),  # Count of racing laps only
                 "avg_lap_time": avg_lap_time,
                 "consistency": consistency,
                 "visible": True,  # Default visibility state

--- a/laptimes/models.py
+++ b/laptimes/models.py
@@ -23,9 +23,15 @@ class Session(models.Model):
             models.Index(fields=["track"]),  # For filtering/searching by track
             models.Index(fields=["car"]),  # For filtering/searching by car
             models.Index(fields=["session_type"]),  # For session type filtering
-            models.Index(fields=["track", "-upload_date"]),  # Compound index for track + date
-            models.Index(fields=["car", "-upload_date"]),    # Compound index for car + date
-            models.Index(fields=["session_type", "-upload_date"]),  # Compound index for session type + date
+            models.Index(
+                fields=["track", "-upload_date"]
+            ),  # Compound index for track + date
+            models.Index(
+                fields=["car", "-upload_date"]
+            ),  # Compound index for car + date
+            models.Index(
+                fields=["session_type", "-upload_date"]
+            ),  # Compound index for session type + date
         ]
 
     def __str__(self):
@@ -77,7 +83,9 @@ class Session(models.Model):
             # Get all laps for total count display
             all_driver_laps = self.laps.filter(driver_name=driver_name)
             # Get only racing laps for performance calculations
-            driver_racing_laps = self.laps.filter(driver_name=driver_name, lap_number__gt=0)
+            driver_racing_laps = self.laps.filter(
+                driver_name=driver_name, lap_number__gt=0
+            )
             racing_lap_times = [lap.total_time for lap in driver_racing_laps]
 
             # Use all laps count for display, but racing laps for calculations

--- a/laptimes/static/laptimes/css/style.css
+++ b/laptimes/static/laptimes/css/style.css
@@ -21,6 +21,22 @@
   color: white !important;
 }
 
+/* Custom orange styling for out laps (lap 0) */
+.badge.bg-outlap {
+  background-color: #f97316 !important;
+  color: white !important;
+}
+
+.table-outlap {
+  background-color: rgba(249, 115, 22, 0.15) !important;
+  color: inherit !important;
+}
+
+.table-outlap td {
+  background-color: rgba(249, 115, 22, 0.15) !important;
+  color: inherit !important;
+}
+
 /* Custom purple table row for fastest lap - much lighter than badge */
 .table-purple {
   background-color: rgba(139, 92, 246, 0.15) !important;

--- a/laptimes/templates/laptimes/session_detail.html
+++ b/laptimes/templates/laptimes/session_detail.html
@@ -221,9 +221,13 @@
                 </thead>
                 <tbody>
                     {% for lap in laps %}
-                    <tr {% if lap.total_time == fastest_total %}class="table-purple"{% elif lap.is_pb_total %}class="table-personal-best"{% elif lap.total_time == slowest_total %}class="table-danger"{% endif %}>
+                    <tr {% if lap.lap_number == 0 %}class="table-outlap"{% elif lap.total_time == fastest_total %}class="table-purple"{% elif lap.is_pb_total %}class="table-personal-best"{% elif lap.total_time == slowest_total %}class="table-danger"{% endif %}>
                         <td>
-                            <span class="badge bg-primary">{{ lap.lap_number|add:1 }}</span>
+                            {% if lap.lap_number == 0 %}
+                                <span class="badge bg-outlap">Out</span>
+                            {% else %}
+                                <span class="badge bg-primary">{{ lap.lap_number }}</span>
+                            {% endif %}
                         </td>
                         <td>
                             <span class="fw-bold text-primary">{{ lap.driver_name }}</span>
@@ -235,7 +239,10 @@
     <td>
         {% with idx=forloop.counter0 %}
             {% with highlight=lap.sector_highlights|index:idx %}
-                {% if highlight %}
+                {% if lap.lap_number == 0 %}
+                    <!-- Out lap - no highlighting -->
+                    <span class="text-muted">{{ s|floatformat:3 }}s</span>
+                {% elif highlight %}
                     {% if s|floatformat:3 == highlight.fastest|floatformat:3 %}
                         <span class="badge bg-purple">{{ s|floatformat:3 }}s</span>
                     {% elif s|floatformat:3 == highlight.pb|floatformat:3 %}

--- a/laptimes/tests/__init__.py
+++ b/laptimes/tests/__init__.py
@@ -12,10 +12,10 @@ This package organizes tests into logical modules:
 """
 
 # Import all test classes for test discovery
-from .test_admin import *
-from .test_api import *
-from .test_file_management import *
-from .test_forms import *
-from .test_integration import *
-from .test_models import *
-from .test_views import *
+from .test_admin import *  # noqa: F403
+from .test_api import *  # noqa: F403
+from .test_file_management import *  # noqa: F403
+from .test_forms import *  # noqa: F403
+from .test_integration import *  # noqa: F403
+from .test_models import *  # noqa: F403
+from .test_views import *  # noqa: F403

--- a/laptimes/urls.py
+++ b/laptimes/urls.py
@@ -24,5 +24,9 @@ urlpatterns = [
         name="delete_driver",
     ),
     path("api/session/<int:pk>/", views.session_data_api, name="session_api"),
-    path("api/drivers/autocomplete/", views.driver_autocomplete, name="driver_autocomplete"),
+    path(
+        "api/drivers/autocomplete/",
+        views.driver_autocomplete,
+        name="driver_autocomplete",
+    ),
 ]

--- a/laptimes/views.py
+++ b/laptimes/views.py
@@ -31,29 +31,31 @@ class HomeView(ListView):
         queryset = Session.objects.annotate(lap_count=Count("laps"))
 
         # Apply filters
-        track = self.request.GET.get('track')
-        if track and track != 'all':
+        track = self.request.GET.get("track")
+        if track and track != "all":
             queryset = queryset.filter(track=track)
 
-        car = self.request.GET.get('car')
-        if car and car != 'all':
+        car = self.request.GET.get("car")
+        if car and car != "all":
             queryset = queryset.filter(car=car)
 
-        session_type = self.request.GET.get('session_type')
-        if session_type and session_type != 'all':
+        session_type = self.request.GET.get("session_type")
+        if session_type and session_type != "all":
             queryset = queryset.filter(session_type=session_type)
 
         # Date range filtering
-        date_from = self.request.GET.get('date_from')
-        date_to = self.request.GET.get('date_to')
+        date_from = self.request.GET.get("date_from")
+        date_to = self.request.GET.get("date_to")
         if date_from:
             queryset = queryset.filter(upload_date__gte=date_from)
         if date_to:
             # Add 23:59:59 to include the entire day
-            from django.utils import timezone
             from datetime import datetime, time
+
+            from django.utils import timezone
+
             try:
-                date_to_obj = datetime.strptime(date_to, '%Y-%m-%d')
+                date_to_obj = datetime.strptime(date_to, "%Y-%m-%d")
                 date_to_end = timezone.make_aware(
                     datetime.combine(date_to_obj.date(), time.max)
                 )
@@ -62,7 +64,7 @@ class HomeView(ListView):
                 pass  # Invalid date format, ignore filter
 
         # Search functionality
-        search = self.request.GET.get('search')
+        search = self.request.GET.get("search")
         if search:
             queryset = queryset.filter(
                 Q(session_name__icontains=search)
@@ -72,18 +74,23 @@ class HomeView(ListView):
             ).distinct()
 
         # Sorting
-        sort_by = self.request.GET.get('sort', '-upload_date')
+        sort_by = self.request.GET.get("sort", "-upload_date")
         valid_sort_fields = [
-            'upload_date', '-upload_date',
-            'track', '-track',
-            'car', '-car',
-            'session_type', '-session_type',
-            'lap_count', '-lap_count'
+            "upload_date",
+            "-upload_date",
+            "track",
+            "-track",
+            "car",
+            "-car",
+            "session_type",
+            "-session_type",
+            "lap_count",
+            "-lap_count",
         ]
         if sort_by in valid_sort_fields:
             queryset = queryset.order_by(sort_by)
         else:
-            queryset = queryset.order_by('-upload_date')
+            queryset = queryset.order_by("-upload_date")
 
         return queryset
 
@@ -105,27 +112,36 @@ class HomeView(ListView):
         context["per_page_options"] = [10, 20, 50, 100]
 
         # Add filter options
-        context['tracks'] = Session.objects.values_list('track', flat=True).distinct().order_by('track')
-        context['cars'] = Session.objects.values_list('car', flat=True).distinct().order_by('car')
-        context['session_types'] = Session.objects.values_list('session_type', flat=True).distinct().order_by('session_type')
+        context["tracks"] = (
+            Session.objects.values_list("track", flat=True).distinct().order_by("track")
+        )
+        context["cars"] = (
+            Session.objects.values_list("car", flat=True).distinct().order_by("car")
+        )
+        context["session_types"] = (
+            Session.objects.values_list("session_type", flat=True)
+            .distinct()
+            .order_by("session_type")
+        )
 
         # Current filter values
-        context['current_filters'] = {
-            'track': self.request.GET.get('track', 'all'),
-            'car': self.request.GET.get('car', 'all'),
-            'session_type': self.request.GET.get('session_type', 'all'),
-            'date_from': self.request.GET.get('date_from', ''),
-            'date_to': self.request.GET.get('date_to', ''),
-            'search': self.request.GET.get('search', ''),
-            'sort': self.request.GET.get('sort', '-upload_date'),
+        context["current_filters"] = {
+            "track": self.request.GET.get("track", "all"),
+            "car": self.request.GET.get("car", "all"),
+            "session_type": self.request.GET.get("session_type", "all"),
+            "date_from": self.request.GET.get("date_from", ""),
+            "date_to": self.request.GET.get("date_to", ""),
+            "search": self.request.GET.get("search", ""),
+            "sort": self.request.GET.get("sort", "-upload_date"),
         }
 
         # Add filter count for display
         active_filters = sum(
-            1 for key, value in context['current_filters'].items()
-            if value and value != 'all' and value != '-upload_date'
+            1
+            for key, value in context["current_filters"].items()
+            if value and value != "all" and value != "-upload_date"
         )
-        context['active_filter_count'] = active_filters
+        context["active_filter_count"] = active_filters
 
         return context
 
@@ -388,11 +404,14 @@ class SessionDetailView(ListView):
             driver_pb_total = {}
             for driver in context["drivers"]:
                 driver_racing_laps = [
-                    lap for lap in all_laps
+                    lap
+                    for lap in all_laps
                     if lap.driver_name == driver and lap.lap_number > 0
                 ]
                 if driver_racing_laps:
-                    driver_pb_total[driver] = min(lap.total_time for lap in driver_racing_laps)
+                    driver_pb_total[driver] = min(
+                        lap.total_time for lap in driver_racing_laps
+                    )
             for lap in laps:
                 lap.is_pb_total = (
                     driver_pb_total.get(lap.driver_name) is not None
@@ -405,7 +424,8 @@ class SessionDetailView(ListView):
         # Fastest and slowest overall for each sector - exclude out laps
         for idx in range(context["sector_count"]):
             racing_sector_times = [
-                lap.sectors[idx] for lap in all_laps
+                lap.sectors[idx]
+                for lap in all_laps
                 if len(lap.sectors) > idx and lap.lap_number > 0
             ]
             if racing_sector_times:
@@ -431,12 +451,14 @@ class SessionDetailView(ListView):
         driver_pb = {driver: {} for driver in context["drivers"]}
         for driver in context["drivers"]:
             driver_racing_laps = [
-                lap for lap in all_laps
+                lap
+                for lap in all_laps
                 if lap.driver_name == driver and lap.lap_number > 0
             ]
             for idx in range(context["sector_count"]):
                 racing_sector_times = [
-                    lap.sectors[idx] for lap in driver_racing_laps
+                    lap.sectors[idx]
+                    for lap in driver_racing_laps
                     if len(lap.sectors) > idx
                 ]
                 if racing_sector_times:
@@ -590,12 +612,15 @@ def delete_driver_from_session(request, session_pk, driver_name):
 
 def driver_autocomplete(request):
     """API endpoint for driver name autocomplete"""
-    term = request.GET.get('term', '')
+    term = request.GET.get("term", "")
     if len(term) < 2:  # Only search if at least 2 characters
         return JsonResponse([], safe=False)
 
-    drivers = Lap.objects.filter(
-        driver_name__icontains=term
-    ).values_list('driver_name', flat=True).distinct().order_by('driver_name')[:10]
+    drivers = (
+        Lap.objects.filter(driver_name__icontains=term)
+        .values_list("driver_name", flat=True)
+        .distinct()
+        .order_by("driver_name")[:10]
+    )
 
     return JsonResponse(list(drivers), safe=False)

--- a/test_outlaps.py
+++ b/test_outlaps.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""
+Quick test script to verify out lap functionality
+"""
+import os
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "actimes_project.settings")
+django.setup()
+
+from laptimes.models import Session  # noqa: E402
+
+
+def test_outlap_functionality():
+    print("🔍 Testing Out Lap Functionality")
+    print("=" * 50)
+
+    # Get a session
+    session = Session.objects.first()
+    if not session:
+        print("❌ No sessions found. Upload a JSON file first.")
+        return
+
+    print(f"📊 Testing session: {session}")
+    print()
+
+    # Get out laps and racing laps
+    out_laps = session.laps.filter(lap_number=0)
+    racing_laps = session.laps.filter(lap_number__gt=0)
+
+    print(f"📈 Out laps (lap_number=0): {out_laps.count()}")
+    print(f"🏁 Racing laps (lap_number>0): {racing_laps.count()}")
+    print()
+
+    if out_laps.exists():
+        print("🟠 OUT LAP EXAMPLES:")
+        for lap in out_laps[:3]:
+            print(
+                f"   Driver: {lap.driver_name}, Lap: {lap.lap_number}, Time: {lap.format_time()}"
+            )
+        print()
+
+    if racing_laps.exists():
+        print("🏎️  RACING LAP EXAMPLES:")
+        for lap in racing_laps[:3]:
+            print(
+                f"   Driver: {lap.driver_name}, Lap: {lap.lap_number}, Time: {lap.format_time()}"
+            )
+        print()
+
+    # Test fastest lap calculation (should exclude out laps)
+    fastest_lap = session.get_fastest_lap()
+    if fastest_lap:
+        print(
+            f"⚡ Fastest lap: {fastest_lap.driver_name}, Lap {fastest_lap.lap_number}, {fastest_lap.format_time()}"
+        )
+        if fastest_lap.lap_number == 0:
+            print("❌ ERROR: Fastest lap should not be an out lap!")
+        else:
+            print("✅ Correct: Fastest lap excludes out laps")
+
+    print("\n🎨 TEMPLATE TEST:")
+    print('Out lap badge should show: <span class="badge bg-outlap">Out</span>')
+    print(
+        'Racing lap badge should show: <span class="badge bg-primary">[lap_number]</span>'
+    )
+    print('Out lap row should have: class="table-outlap"')
+
+    print("\n🚀 To test visually:")
+    print("1. Run: source .venv/bin/activate && python manage.py runserver")
+    print("2. Go to: http://127.0.0.1:8000/")
+    print("3. Click on a session to view lap details")
+    print("4. Look for orange 'Out' badges and orange row highlighting")
+    print("5. Hard refresh browser (Cmd+Shift+R / Ctrl+Shift+R) to clear cache")
+
+
+if __name__ == "__main__":
+    test_outlap_functionality()


### PR DESCRIPTION
## Summary
This PR adds comprehensive out lap (lap 0) handling to distinguish between warm-up laps and competitive racing laps, providing more accurate performance analysis.

## Visual Changes ✨
- **Out laps** now display **orange "Out" badges** instead of lap numbers
- **Orange row highlighting** applied to entire out lap rows  
- **Out lap sector times** shown in muted text without performance badges

## Performance Improvements 📊
- **Fastest/slowest lap calculations** now exclude out laps
- **Personal best highlighting** excludes out laps
- **Sector time best/worst highlighting** excludes out laps
- **Driver statistics** (best lap, average, consistency) exclude out laps
- **Optimal lap time calculations** exclude out laps

## Technical Changes 🔧
- Added CSS classes: `.badge.bg-outlap`, `.table-outlap`
- Updated template logic to detect `lap_number == 0`
- Modified `views.py` to filter racing laps (`lap_number > 0`) for calculations
- Updated `models.py` methods to exclude out laps from performance metrics
- Enhanced `get_fastest_lap()` method to filter out `lap_number=0`

## Testing ✅
- ✅ **18/18 model tests** pass
- ✅ **14/14 view tests** pass  
- ✅ **1/1 integration test** pass
- ✅ Added test script for manual verification (`test_outlaps.py`)

## Screenshots
Before: First lap incorrectly included in fastest lap calculations
After: Out laps clearly distinguished with orange styling, excluded from performance metrics

## Breaking Changes
None - maintains backward compatibility with existing data.

## How to Test
1. Run the development server: `python manage.py runserver`
2. Navigate to any session detail page
3. **Hard refresh browser** (Cmd+Shift+R / Ctrl+Shift+R) to clear cache
4. Observe orange "Out" badges and row highlighting for lap 0
5. Verify fastest lap excludes out laps
6. Run test script: `python test_outlaps.py`

🤖 Generated with [Claude Code](https://claude.ai/code)